### PR TITLE
Fix: annotate model after .mat and .yml export, but before .xml export

### DIFF
--- a/code/masterScriptWormGEM.m
+++ b/code/masterScriptWormGEM.m
@@ -43,9 +43,9 @@ if isequal(rxnAssoc.rxns, wormGEM.rxns) && isequal(metAssoc.mets, wormGEM.mets)
     exportTsvFile(metAssoc,'../model/metabolites.tsv');
 end
 
-wormGEM = annotateGEM(wormGEM,'../model',{'rxn','met'});  % add annotation data to structure
-wormGEM.id = regexprep(wormGEM.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
 save('../model/Worm-GEM.mat', 'wormGEM');
 exportYaml(wormGEM, '../model/Worm-GEM.yml');
+wormGEM = annotateGEM(wormGEM,'../model',{'rxn','met'});  % add annotation data to structure
+wormGEM.id = regexprep(wormGEM.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
 exportModel(wormGEM, '../model/Worm-GEM.xml');
 


### PR DESCRIPTION
### Main improvements in this PR:
As described in [Issue 16 of Mouse-GEM](https://github.com/SysBioChalmers/Mouse-GEM/issues/16) and addressed in PR [18](https://github.com/SysBioChalmers/Mouse-GEM/pull/18) of that same repo, the master script for regenerating the model files (`masterScriptWormGEM.m` in this repo) is modified such that the addition of non-standard metabolite and reaction annotation fields are only added to the SBML (`.xml`) version of the model. The `.mat` and `.yml` versions should not contain these fields.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch